### PR TITLE
Allow configuring consumer's min_bytes and max_wait_time

### DIFF
--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -67,16 +67,16 @@ listeners:
     topic: test
     # id of the group that the consumer should join
     group_id: test-1
+    # Number of threads created for this listener, each thread will behave as an independent consumer.
+    # They don't share any state
+    max_concurrency: 1
     # Once the consumer group has checkpointed its progress in the topic's partitions,
     # the consumers will always start from the checkpointed offsets, regardless of config
     # As such, this setting only applies when the consumer initially starts consuming from a topic
     start_from_beginning: true
     # maximum amount of data fetched from a single partition at a time
     max_bytes_per_partition: 524288 # 512 KB
-    # Number of threads created for this listener, each thread will behave as an independent consumer.
-    # They don't share any state
-    max_concurrency: 1
     # Minimum number of bytes to read before returning messages from the server; if `max_wait_time` is reached, this is ignored.
     min_bytes: 1
-    # Maximum duration of time to wait before returning messages from the server, in seconds, default: 5.
-    max_wait_time: 0.1
+    # Maximum duration of time to wait before returning messages from the server, in seconds
+    max_wait_time: 5

--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -76,3 +76,7 @@ listeners:
     # Number of threads created for this listener, each thread will behave as an independent consumer.
     # They don't share any state
     max_concurrency: 1
+    # Minimum number of bytes to read before returning messages from the server; if `max_wait_time` is reached, this is ignored.
+    min_bytes: 1
+    # Maximum duration of time to wait before returning messages from the server, in seconds, default: 5.
+    max_wait_time: 0.1

--- a/lib/phobos/executor.rb
+++ b/lib/phobos/executor.rb
@@ -1,7 +1,7 @@
 module Phobos
   class Executor
     include Phobos::Instrumentation
-    LISTENER_OPTS = %i(handler group_id topic start_from_beginning max_bytes_per_partition).freeze
+    LISTENER_OPTS = %i(handler group_id topic min_bytes max_wait_time start_from_beginning max_bytes_per_partition).freeze
 
     def initialize
       @threads = Concurrent::Array.new

--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -16,10 +16,7 @@ module Phobos
         start_from_beginning: start_from_beginning,
         max_bytes_per_partition: max_bytes_per_partition
       }
-      @consumer_opts = compact({
-        min_bytes: min_bytes,
-        max_wait_time: max_wait_time
-      })
+      @consumer_opts = compact(min_bytes: min_bytes, max_wait_time: max_wait_time)
       @kafka_client = Phobos.create_kafka_client
       @producer_enabled = @handler_class.ancestors.include?(Phobos::Producer)
     end
@@ -39,7 +36,7 @@ module Phobos
       end
 
       begin
-        @consumer.each_batch(**@consumer_opts) do |batch|
+        @consumer.each_batch(@consumer_opts) do |batch|
           batch_metadata = {
             batch_size: batch.messages.count,
             partition: batch.partition,
@@ -155,7 +152,7 @@ module Phobos
     end
 
     def compact(hash)
-      hash.delete_if { |k, v| v.nil? }
+      hash.delete_if { |_, v| v.nil? }
     end
   end
 end

--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -7,7 +7,7 @@ module Phobos
 
     attr_reader :group_id, :topic, :id
 
-    def initialize(handler:, group_id:, topic:, start_from_beginning: true, max_bytes_per_partition: DEFAULT_MAX_BYTES_PER_PARTITION)
+    def initialize(handler:, group_id:, topic:, min_bytes: nil, max_wait_time: nil, start_from_beginning: true, max_bytes_per_partition: DEFAULT_MAX_BYTES_PER_PARTITION)
       @id = SecureRandom.hex[0...6]
       @handler_class = handler
       @group_id = group_id
@@ -16,6 +16,10 @@ module Phobos
         start_from_beginning: start_from_beginning,
         max_bytes_per_partition: max_bytes_per_partition
       }
+      @consumer_opts = compact({
+        min_bytes: min_bytes,
+        max_wait_time: max_wait_time
+      })
       @kafka_client = Phobos.create_kafka_client
       @producer_enabled = @handler_class.ancestors.include?(Phobos::Producer)
     end
@@ -35,7 +39,7 @@ module Phobos
       end
 
       begin
-        @consumer.each_batch do |batch|
+        @consumer.each_batch(**@consumer_opts) do |batch|
           batch_metadata = {
             batch_size: batch.messages.count,
             partition: batch.partition,
@@ -148,6 +152,10 @@ module Phobos
     def create_kafka_consumer
       configs = Phobos.config.consumer_hash.select { |k| KAFKA_CONSUMER_OPTS.include?(k) }
       @kafka_client.consumer({group_id: group_id}.merge(configs))
+    end
+
+    def compact(hash)
+      hash.delete_if { |k, v| v.nil? }
     end
   end
 end

--- a/spec/lib/phobos/executor_spec.rb
+++ b/spec/lib/phobos/executor_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Phobos::Executor do
   include Phobos::Producer
+  MAX_WAIT_TIME = 0.1 # no need to wait for 5 seconds in tests
 
   class TestHandler1 < Phobos::EchoHandler; end
   class TestHandler2 < Phobos::EchoHandler; end
@@ -13,8 +14,8 @@ RSpec.describe Phobos::Executor do
   let(:handler2) { Phobos::EchoHandler.new }
   let(:listeners) do
     [
-      Phobos::DeepStruct.new(handler: TestHandler1.to_s, topic: topics.first, group_id: random_group_id, start_from_beginning: true),
-      Phobos::DeepStruct.new(handler: TestHandler2.to_s, topic: topics.last, group_id: random_group_id, start_from_beginning: true)
+      Phobos::DeepStruct.new(handler: TestHandler1.to_s, topic: topics.first, group_id: random_group_id, start_from_beginning: true, max_wait_time: MAX_WAIT_TIME),
+      Phobos::DeepStruct.new(handler: TestHandler2.to_s, topic: topics.last, group_id: random_group_id, start_from_beginning: true, max_wait_time: MAX_WAIT_TIME)
     ]
   end
 
@@ -65,8 +66,8 @@ RSpec.describe Phobos::Executor do
   context 'with max concurrency > 1' do
     let(:listeners) do
       [
-        Phobos::DeepStruct.new(handler: TestHandler1.to_s, topic: topics.first, group_id: random_group_id, start_from_beginning: true, max_concurrency: 2),
-        Phobos::DeepStruct.new(handler: TestHandler2.to_s, topic: topics.last, group_id: random_group_id, start_from_beginning: true)
+        Phobos::DeepStruct.new(handler: TestHandler1.to_s, topic: topics.first, group_id: random_group_id, start_from_beginning: true, max_concurrency: 2, max_wait_time: MAX_WAIT_TIME),
+        Phobos::DeepStruct.new(handler: TestHandler2.to_s, topic: topics.last, group_id: random_group_id, start_from_beginning: true, max_wait_time: MAX_WAIT_TIME)
       ]
     end
 


### PR DESCRIPTION
Apart from adding [the configuration options](https://github.com/zendesk/ruby-kafka/blob/9bb557efe545ab393b2143ac9c8a96dc7539b2e2/lib/kafka/consumer.rb#L213) from ruby-kafka, this change speeds up the test run 2x by not waiting for 5 seconds every time a listener is shut down in the tests.