### PR TITLE
Add support for erb syntax in phobos config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.0 (2017-06-15)
+
+- [enhancement] Add support for erb syntax in phobos config file #26
+
 ## 1.2.1 (2016-10-12)
 
 - [bugfix] Ensure JSON layout for log files

--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ When using Phobos __executors__ you don't care about how listeners are created, 
 ### <a name="usage-configuration-file"></a> Configuration file
 The configuration file is organized in 6 sections. Take a look at the example file, [config/phobos.yml.example](https://github.com/klarna/phobos/blob/master/config/phobos.yml.example).
 
+The file will be parsed through ERB so ERB syntax/file extension is supported beside the YML format.
+
 __logger__ configures the logger for all Phobos components, it automatically outputs to `STDOUT` and it saves the log in the configured file
 
 __kafka__ provides configurations for every `Kafka::Client` created over the application. All [options supported by  `ruby-kafka`][ruby-kafka-client] can be provided.

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -29,7 +29,7 @@ module Phobos
 
     def configure(yml_path)
       ENV['RAILS_ENV'] = ENV['RACK_ENV'] ||= 'development'
-      @config = DeepStruct.new(YAML.load_file(File.expand_path(yml_path)))
+      @config = DeepStruct.new(YAML.load(ERB.new(File.read(File.expand_path(yml_path))).result))
       @config.class.send(:define_method, :producer_hash) { Phobos.config.producer&.to_hash }
       @config.class.send(:define_method, :consumer_hash) { Phobos.config.consumer&.to_hash }
       configure_logger

--- a/lib/phobos/version.rb
+++ b/lib/phobos/version.rb
@@ -1,3 +1,3 @@
 module Phobos
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end

--- a/spec/fixtures/phobos_config.yml.erb
+++ b/spec/fixtures/phobos_config.yml.erb
@@ -1,0 +1,5 @@
+logger:
+  file: log/phobos.log
+  
+kafka:
+  client_id: <%='InjectedThroughERB'%>

--- a/spec/lib/phobos_spec.rb
+++ b/spec/lib/phobos_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe Phobos do
       expect(Phobos.config).to_not be_nil
       expect(Phobos.config.kafka).to_not be_nil
     end
+
+    context 'when using erb syntax in configuration file' do
+      it 'parses it correctly' do
+        Phobos.instance_variable_set(:@config, nil)
+        Phobos.configure('spec/fixtures/phobos_config.yml.erb')
+
+        expect(Phobos.config).to_not be_nil
+        expect(Phobos.config.kafka.client_id).to eq('InjectedThroughERB')
+      end
+    end
   end
 
   describe '.create_kafka_client' do


### PR DESCRIPTION
Adds the possibility to have ERB syntax in the config file so that you can inject parameters

like:

```yml
logger:
  file: log/phobos.log
  
kafka:
  client_id: <%='InjectedThroughERB'%>
```