### PR TITLE
Add support for hash provided settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,14 @@ MyProducer
 
 When running as a standalone service, Phobos sets up a `Listener` and `Executor` for you. When you use Phobos as a library in your own project, you need to set these components up yourself.
 
-First, call the method `configure` with the path of your configuration file
+First, call the method `configure` with the path of your configuration file or with configuration settings hash.
 
 ```ruby
 Phobos.configure('config/phobos.yml')
+```
+or
+```ruby
+Phobos.configure(kafka: { client_id: 'phobos' }, logger: { file: 'log/phobos.log' })
 ```
 
 __Listener__ connects to Kafka and acts as your consumer. To create a listener you need a handler class, a topic, and a group id.

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -27,9 +27,9 @@ module Phobos
     attr_reader :config, :logger
     attr_accessor :silence_log
 
-    def configure(yml_path)
+    def configure(configuration)
       ENV['RAILS_ENV'] = ENV['RACK_ENV'] ||= 'development'
-      @config = DeepStruct.new(YAML.load(ERB.new(File.read(File.expand_path(yml_path))).result))
+      @config = DeepStruct.new(fetch_settings(configuration))
       @config.class.send(:define_method, :producer_hash) { Phobos.config.producer&.to_hash }
       @config.class.send(:define_method, :consumer_hash) { Phobos.config.consumer&.to_hash }
       configure_logger
@@ -72,6 +72,14 @@ module Phobos
 
       @logger = Logging.logger[self]
       @logger.appenders = appenders
+    end
+
+    private
+
+    def fetch_settings(configuration)
+      return configuration.to_h if configuration.respond_to?(:to_h)
+
+      YAML.load(ERB.new(File.read(File.expand_path(configuration))).result)
     end
   end
 end

--- a/spec/lib/phobos_spec.rb
+++ b/spec/lib/phobos_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe Phobos do
         expect(Phobos.config.kafka.client_id).to eq('InjectedThroughERB')
       end
     end
+
+    context 'when providing hash with configuration settings' do
+      it 'parses it correctly' do
+        Phobos.instance_variable_set(:@config, nil)
+        Phobos.configure(YAML.load(File.read(phobos_config_path)))
+
+        expect(Phobos.config).to_not be_nil
+        expect(Phobos.config.kafka).to_not be_nil
+      end
+    end
   end
 
   describe '.create_kafka_client' do

--- a/spec/lib/phobos_spec.rb
+++ b/spec/lib/phobos_spec.rb
@@ -21,11 +21,17 @@ RSpec.describe Phobos do
 
     context 'when providing hash with configuration settings' do
       it 'parses it correctly' do
+        configuration_settings = {
+          kafka: { client_id: 'client_id' },
+          logger: { file: 'log/phobos.log' }
+        }
+
         Phobos.instance_variable_set(:@config, nil)
-        Phobos.configure(YAML.load(File.read(phobos_config_path)))
+        Phobos.configure(configuration_settings)
 
         expect(Phobos.config).to_not be_nil
-        expect(Phobos.config.kafka).to_not be_nil
+        expect(Phobos.config.kafka.client_id).to eq('client_id')
+        expect(Phobos.config.logger.file).to eq('log/phobos.log')
       end
     end
   end


### PR DESCRIPTION
Hello! I would like to propose an option to import settings to Phobos from a Hash-like object.

Why?
I've already have a settings managing mechanism in place (https://github.com/railsconfig/config). 
It takes care about settings inheritance and supports several environments. 
I would like to reuse my current configuration setup without adding extra `phobos.yml` files for every environment.

This PR adds an option to provide a hash to `Phobos.configure` method.