### PR TITLE
Make configuration, especially of listeners, more flexible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ By default, the __start__ command will look for the configuration file at `confi
 ```sh
 $ phobos start -c /var/configs/my.yml -b /opt/apps/boot.rb
 ```
+
+You may also choose to configure phobos with a hash from within your boot file.
+In this case, disable loading the config file with the `--skip-config` option:
+
+```sh
+$ phobos start -b /opt/apps/boot.rb --skip-config 
+```
+
 ### <a name="usage-consuming-messages-from-kafka"></a> Consuming messages from Kafka
 
 Messages from Kafka are consumed using __handlers__. You can use Phobos __executors__ or include it in your own project [as a library](#usage-as-library), but __handlers__ will always be used. To create a handler class, simply include the module `Phobos::Handler`. This module allows Phobos to manage the life cycle of your handler.

--- a/README.md
+++ b/README.md
@@ -311,6 +311,20 @@ __listeners__ is the list of listeners configured, each listener represents a co
 [ruby-kafka-consumer]: http://www.rubydoc.info/gems/ruby-kafka/Kafka%2FClient%3Aconsumer
 [ruby-kafka-producer]: http://www.rubydoc.info/gems/ruby-kafka/Kafka%2FClient%3Aproducer
 
+#### Additional listener configuration
+
+In some cases it's useful to  share _most_ of the configuration between
+multiple phobos processes, but have each process run different listeners. In
+that case, a separate yaml file can be created and loaded with the `-l` flag.
+Example:
+
+```sh
+$ phobos start -c /var/configs/my.yml -l /var/configs/additional_listeners.yml
+```
+
+Note that the config file _must_ still specify a listeners section, though it
+can be empty.
+
 ### <a name="usage-instrumentation"></a> Instrumentation
 
 Some operations are instrumented using [Active Support Notifications](http://api.rubyonrails.org/classes/ActiveSupport/Notifications.html).

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -32,8 +32,14 @@ module Phobos
       @config = DeepStruct.new(fetch_settings(configuration))
       @config.class.send(:define_method, :producer_hash) { Phobos.config.producer&.to_hash }
       @config.class.send(:define_method, :consumer_hash) { Phobos.config.consumer&.to_hash }
+      @config.listeners ||= []
       configure_logger
       logger.info { Hash(message: 'Phobos configured', env: ENV['RACK_ENV']) }
+    end
+
+    def add_listeners(listeners_configuration)
+      listeners_config = DeepStruct.new(fetch_settings(listeners_configuration))
+      @config.listeners += listeners_config.listeners
     end
 
     def create_kafka_client

--- a/lib/phobos/cli.rb
+++ b/lib/phobos/cli.rb
@@ -51,7 +51,7 @@ module Phobos
              default: 'phobos_boot.rb'
       option :listeners,
              aliases: ['-l'],
-             banner: 'Listeners config file'
+             banner: 'Separate listeners config file (optional)'
       option :skip_config,
              default: false,
              type: :boolean,

--- a/lib/phobos/cli.rb
+++ b/lib/phobos/cli.rb
@@ -49,6 +49,13 @@ module Phobos
              aliases: ['-b'],
              banner: 'File path to load application specific code',
              default: 'phobos_boot.rb'
+      option :listeners,
+             aliases: ['-l'],
+             banner: 'Listeners config file'
+      option :skip_config,
+             default: false,
+             type: :boolean,
+             banner: 'Skip config file'
       def start
         Phobos::CLI::Start.new(options).execute
       end

--- a/lib/phobos/cli/start.rb
+++ b/lib/phobos/cli/start.rb
@@ -4,14 +4,28 @@ module Phobos
   module CLI
     class Start
       def initialize(options)
-        @config_file = File.expand_path(options[:config])
+        unless options[:skip_config]
+          @config_file = File.expand_path(options[:config])
+        end
         @boot_file = File.expand_path(options[:boot])
+
+        if options[:listeners]
+          @listeners_file = File.expand_path(options[:listeners])
+        end
       end
 
       def execute
-        validate_config_file!
-        Phobos.configure(config_file)
+        if config_file
+          validate_config_file!
+          Phobos.configure(config_file)
+        end
+
         load_boot_file
+
+        if listeners_file
+          Phobos.add_listeners(listeners_file)
+        end
+
         validate_listeners!
 
         Phobos::CLI::Runner.new.run!
@@ -19,7 +33,7 @@ module Phobos
 
       private
 
-      attr_reader :config_file, :boot_file
+      attr_reader :config_file, :boot_file, :listeners_file
 
       def validate_config_file!
         unless File.exist?(config_file)

--- a/spec/fixtures/extra_listeners.yml
+++ b/spec/fixtures/extra_listeners.yml
@@ -1,0 +1,6 @@
+listeners:
+  - handler: Phobos::Handler
+    topic: test
+    start_from_beginning: true
+    group_id: test-1
+    max_concurrency: 1

--- a/spec/lib/phobos/cli/start_spec.rb
+++ b/spec/lib/phobos/cli/start_spec.rb
@@ -8,11 +8,24 @@ RSpec.describe Phobos::CLI::Start do
       expect { start.execute }.to raise_error SystemExit
     end
 
-    it 'calls Phobos.configure with config file' do
-      allow(Phobos::CLI::Runner).to receive(:new).and_return(double('Phobos::CLI::Runner', run!: true))
-      start = Phobos::CLI::Start.new(config: phobos_config_path, boot: 'phobos_boot.rb')
-      expect(Phobos).to receive(:configure).with(phobos_config_path).and_call_original
-      expect { start.execute }.to_not raise_error
+    context "when called with `skip_config` option not passed" do
+      let(:start) { Phobos::CLI::Start.new(config: phobos_config_path, boot: 'phobos_boot.rb') }
+
+      it 'calls Phobos.configure with config file' do
+        allow(Phobos::CLI::Runner).to receive(:new).and_return(double('Phobos::CLI::Runner', run!: true))
+        expect(Phobos).to receive(:configure).with(phobos_config_path).and_call_original
+        expect { start.execute }.to_not raise_error
+      end
+    end
+
+    context 'when called with `skip_config` option set to true' do
+      let(:start) { Phobos::CLI::Start.new(config: phobos_config_path, boot: 'phobos_boot.rb', skip_config: true) }
+
+      it 'does not call Phobos.configure' do
+        allow(Phobos::CLI::Runner).to receive(:new).and_return(double('Phobos::CLI::Runner', run!: true))
+        expect(Phobos).to_not receive(:configure)
+        expect { start.execute }.to_not raise_error
+      end
     end
 
     it 'validates configured handlers' do
@@ -27,6 +40,15 @@ RSpec.describe Phobos::CLI::Start do
       start = Phobos::CLI::Start.new(config: phobos_config_path, boot: 'spec/fixtures/boot_test.rb')
       expect { start.execute }.to_not raise_error
       expect($boot_test_loaded).to eql true
+    end
+
+    context 'when given a listeners file' do
+      let(:start) { Phobos::CLI::Start.new(config: phobos_config_path, boot: 'phobos_boot.rb', listeners: 'spec/fixtures/extra_listeners.yml') }
+
+      it 'calls Phobos.add_listeners with listeners file' do
+        allow(Phobos::CLI::Runner).to receive(:new).and_return(double('Phobos::CLI::Runner', run!: true))
+        expect { start.execute }.to_not raise_error
+      end
     end
 
     it 'starts Phobos::CLI::Runner' do

--- a/spec/lib/phobos/cli_spec.rb
+++ b/spec/lib/phobos/cli_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe Phobos::CLI do
       args = ['start', '-c', 'config/phobos.yml', '-b', 'boot.rb']
       Phobos::CLI::Commands.start(args)
     end
+
+    it 'accepts optional -l' do
+      expect(Phobos::CLI::Start)
+        .to receive(:new)
+        .with(hash_including('listeners' => 'config/listeners.yml'))
+        .and_return(double('Phobos::CLI::Start', execute: true))
+
+      args = ['start', '-c', 'config/phobos.yml', '-l', 'config/listeners.yml']
+      Phobos::CLI::Commands.start(args)
+    end
   end
 
 end

--- a/spec/lib/phobos_spec.rb
+++ b/spec/lib/phobos_spec.rb
@@ -36,6 +36,28 @@ RSpec.describe Phobos do
     end
   end
 
+  describe '.add_listeners' do
+    before { Phobos.configure(phobos_config_path) }
+    let(:new_listeners) do
+      {
+        listeners: [
+          {
+            handler: "ListenerTestHandler"
+          }
+        ]
+      }
+    end
+
+    it 'adds the given listeners to the previoiusly configured listeners' do
+      Phobos.add_listeners(new_listeners)
+      # Listener config loaded from phobos main config has not been
+      # overwritten:
+      expect(Phobos.config.listeners).to include(have_attributes(handler: "Phobos::EchoHandler"))
+      # Listener config passed in has been added:
+      expect(Phobos.config.listeners).to include(have_attributes(handler: "ListenerTestHandler"))
+    end
+  end
+
   describe '.create_kafka_client' do
     before { Phobos.configure(phobos_config_path) }
 


### PR DESCRIPTION
- Allows loading config from a file during startup to be disabled, useful if you prefer to configure phobos with a hash in ruby instead of with a yaml file.
- Allows a separate listeners file to be specified, making it easy to run multiple phobos processes with different sets of listeners.