### PR TITLE
Add support for configuring a topic prefix and group id prefix.

### DIFF
--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -10,8 +10,8 @@ module Phobos
     def initialize(handler:, group_id:, topic:, min_bytes: nil, max_wait_time: nil, force_encoding: nil, start_from_beginning: true, max_bytes_per_partition: DEFAULT_MAX_BYTES_PER_PARTITION)
       @id = SecureRandom.hex[0...6]
       @handler_class = handler
-      @group_id = group_id
-      @topic = topic
+      @group_id = prefix_group_id(group_id)
+      @topic = prefix_topic(topic)
       @subscribe_opts = {
         start_from_beginning: start_from_beginning,
         max_bytes_per_partition: max_bytes_per_partition
@@ -166,6 +166,14 @@ module Phobos
 
     def compact(hash)
       hash.delete_if { |_, v| v.nil? }
+    end
+
+    def prefix_group_id(group_id)
+      "#{Phobos.config.try(:group_id_prefix)}#{group_id}"
+    end
+
+    def prefix_topic(topic)
+      "#{Phobos.config.try(:topic_prefix)}#{topic}"
     end
   end
 end


### PR DESCRIPTION
This functionality is useful for those using the "basic" kafka plans on Heroku,
where all topics and all consumer groups _must_ be prefixed with a given value.
See https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#differences-to-dedicated-kafka-plans for more.

This may also be useful on other SASS Kafka services that operate in a similar manner, or when multiple apps share the same Kafka cluster and it's desirable to prefix topics and/or consumer groups per app.

NOTE: If there's a better way to implement this (maybe the listener isn't the best place?) I'd be happy to discuss and make changes.