### PR TITLE
Add each_message support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for outputting logs as json #50
 - Make configuration, especially of listeners, more flexible. #31
 - Phobos Discord chat
+- Support for consuming `each_message` instead of `each_batch` via the delivery listener option. #21
+- Instantiate a single handler class instance and use that both for `consume` and `before_consume`. #47
 
 ### Changed
 - Pin ruby-kafka version to < 0.5.0 #48

--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -98,8 +98,8 @@ listeners:
     # Apply this encoding to the message payload, if blank it uses the original encoding. This property accepts values
     # defined by the ruby Encoding class (https://ruby-doc.org/core-2.3.0/Encoding.html). Ex: UTF_8, ASCII_8BIT, etc
     force_encoding:
-    # Change this to false if consuming messages individually
-    consume_in_batches: true
+    # Change this to 'message' if consuming messages individually. Defaults to 'batch'
+    delivery: batch
     # Use this if custom backoff is required for a listener
     backoff:
       min_ms: 500

--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -98,7 +98,15 @@ listeners:
     # Apply this encoding to the message payload, if blank it uses the original encoding. This property accepts values
     # defined by the ruby Encoding class (https://ruby-doc.org/core-2.3.0/Encoding.html). Ex: UTF_8, ASCII_8BIT, etc
     force_encoding:
-    # Change this to 'message' if consuming messages individually. Defaults to 'batch'
+    # Specify the delivery method for a listener.
+    # Possible values: [`message`, `batch` (default)]
+    #  - `message` will yield individual messages from Ruby Kafka using `each_message` and will commit/heartbeat at every consumed message.
+    #     This is overall a bit slower than using batch, but easier to configure.
+    #  - `batch` will yield batches from Ruby Kafka using `each_batch`, and commit/heartbeat at every consumed batch.
+    #     Due to implementation in Ruby Kafka, it should be noted that when configuring large batch sizes in combination with taking long time to consume messages,
+    #     your consumers might get kicked from the Kafka cluster for not sending a heartbeat within the expected interval.
+    #     Take this into consideration when determining your configuration.
+    # Note: Ultimately commit/heartbeart will depend on the offset commit options and the heartbeat interval.
     delivery: batch
     # Use this if custom backoff is required for a listener
     backoff:

--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -98,6 +98,8 @@ listeners:
     # Apply this encoding to the message payload, if blank it uses the original encoding. This property accepts values
     # defined by the ruby Encoding class (https://ruby-doc.org/core-2.3.0/Encoding.html). Ex: UTF_8, ASCII_8BIT, etc
     force_encoding:
+    # Change this to false if consuming messages individually
+    consume_in_batches: true
     # Use this if custom backoff is required for a listener
     backoff:
       min_ms: 500

--- a/lib/phobos/actions/process_batch.rb
+++ b/lib/phobos/actions/process_batch.rb
@@ -11,7 +11,6 @@ module Phobos
 
       def execute
         @batch.messages.each do |message|
-          backoff = @listener.create_exponential_backoff
           metadata = @listener_metadata.merge(
             key: message.key,
             partition: message.partition,
@@ -19,40 +18,17 @@ module Phobos
             retry_count: 0
           )
 
-          begin
-            instrument('listener.process_message', metadata) do |metadata|
-              time_elapsed = measure do
-                Phobos::Actions::ProcessMessage.new(
-                  listener: @listener,
-                  message: message,
-                  metadata: metadata,
-                  encoding: @listener.encoding
-                ).execute
-              end
-              metadata.merge!(time_elapsed: time_elapsed)
-            end
-          rescue => e
-            retry_count = metadata[:retry_count]
-            interval = backoff.interval_at(retry_count).round(2)
-
-            error = {
-              waiting_time: interval,
-              exception_class: e.class.name,
-              exception_message: e.message,
-              backtrace: e.backtrace
-            }
-
-            instrument('listener.retry_handler_error', error.merge(metadata)) do
-              Phobos.logger.error do
-                { message: "error processing message, waiting #{interval}s" }.merge(error).merge(metadata)
-              end
-
-              sleep interval
-              metadata.merge!(retry_count: retry_count + 1)
+          instrument('listener.process_message', metadata) do |metadata|
+            time_elapsed = measure do
+              Phobos::Actions::ProcessMessage.new(
+                listener: @listener,
+                message: message,
+                listener_metadata: @listener_metadata,
+                encoding: @listener.encoding
+              ).execute
             end
 
-            raise Phobos::AbortError if @listener.should_stop?
-            retry
+            metadata.merge!(time_elapsed: time_elapsed)
           end
         end
       end

--- a/lib/phobos/actions/process_batch.rb
+++ b/lib/phobos/actions/process_batch.rb
@@ -23,8 +23,7 @@ module Phobos
               Phobos::Actions::ProcessMessage.new(
                 listener: @listener,
                 message: message,
-                listener_metadata: @listener_metadata,
-                encoding: @listener.encoding
+                listener_metadata: @listener_metadata
               ).execute
             end
           end

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -58,10 +58,11 @@ module Phobos
       def process_message(payload)
         instrument('listener.process_message', @metadata) do |metadata|
           time_elapsed = measure do
-            decoded_payload = @listener.handler_class.new.before_consume(payload)
+            handler = @listener.handler_class.new
+            preprocessed_payload = handler.before_consume(payload)
 
-            @listener.handler_class.around_consume(decoded_payload, @metadata) do
-              @listener.handler_class.new.consume(decoded_payload, @metadata)
+            @listener.handler_class.around_consume(preprocessed_payload, @metadata) do
+              handler.consume(preprocessed_payload, @metadata)
             end
           end
 

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -8,26 +8,32 @@ module Phobos
         @message = message
         @listener_metadata = listener_metadata
         @encoding = encoding
+        @metadata = listener_metadata.merge(
+          key: message.key,
+          partition: message.partition,
+          offset: message.offset,
+          retry_count: 0
+        )
       end
 
       def execute
-        metadata = @listener_metadata.merge(
-          key: @message.key,
-          partition: @message.partition,
-          offset: @message.offset,
-          retry_count: 0
-        )
-
         backoff = @listener.create_exponential_backoff
         payload = force_encoding(@message.value)
 
         begin
-          decoded_payload = @listener.handler_class.new.before_consume(payload)
-          @listener.handler_class.around_consume(decoded_payload, metadata) do
-            @listener.handler_class.new.consume(decoded_payload, metadata)
+          instrument('listener.process_message', @metadata) do |metadata|
+            time_elapsed = measure do
+              decoded_payload = @listener.handler_class.new.before_consume(payload)
+
+              @listener.handler_class.around_consume(decoded_payload, @metadata) do
+                @listener.handler_class.new.consume(decoded_payload, @metadata)
+              end
+            end
+
+            metadata.merge!(time_elapsed: time_elapsed)
           end
         rescue => e
-          retry_count = metadata[:retry_count]
+          retry_count = @metadata[:retry_count]
           interval = backoff.interval_at(retry_count).round(2)
 
           error = {
@@ -37,13 +43,13 @@ module Phobos
             backtrace: e.backtrace
           }
 
-          instrument('listener.retry_handler_error', error.merge(metadata)) do
+          instrument('listener.retry_handler_error', error.merge(@metadata)) do
             Phobos.logger.error do
-              { message: "error processing message, waiting #{interval}s" }.merge(error).merge(metadata)
+              { message: "error processing message, waiting #{interval}s" }.merge(error).merge(@metadata)
             end
 
             sleep interval
-            metadata.merge!(retry_count: retry_count + 1)
+            @metadata.merge!(retry_count: retry_count + 1)
           end
 
           raise Phobos::AbortError if @listener.should_stop?

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -3,6 +3,8 @@ module Phobos
     class ProcessMessage
       include Phobos::Instrumentation
 
+      attr_reader :metadata
+
       def initialize(listener:, message:, listener_metadata:, encoding:)
         @listener = listener
         @message = message

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -1,18 +1,53 @@
 module Phobos
   module Actions
     class ProcessMessage
-      def initialize(listener:, message:, metadata:, encoding:)
+      include Phobos::Instrumentation
+
+      def initialize(listener:, message:, listener_metadata:, encoding:)
         @listener = listener
         @message = message
-        @metadata = metadata
+        @listener_metadata = listener_metadata
         @encoding = encoding
       end
 
       def execute
+        metadata = @listener_metadata.merge(
+          key: @message.key,
+          partition: @message.partition,
+          offset: @message.offset,
+          retry_count: 0
+        )
+
+        backoff = @listener.create_exponential_backoff
         payload = force_encoding(@message.value)
-        decoded_payload = @listener.handler_class.new.before_consume(payload)
-        @listener.handler_class.around_consume(decoded_payload, @metadata) do
-          @listener.handler_class.new.consume(decoded_payload, @metadata)
+
+        begin
+          decoded_payload = @listener.handler_class.new.before_consume(payload)
+          @listener.handler_class.around_consume(decoded_payload, metadata) do
+            @listener.handler_class.new.consume(decoded_payload, metadata)
+          end
+        rescue => e
+          retry_count = metadata[:retry_count]
+          interval = backoff.interval_at(retry_count).round(2)
+
+          error = {
+            waiting_time: interval,
+            exception_class: e.class.name,
+            exception_message: e.message,
+            backtrace: e.backtrace
+          }
+
+          instrument('listener.retry_handler_error', error.merge(metadata)) do
+            Phobos.logger.error do
+              { message: "error processing message, waiting #{interval}s" }.merge(error).merge(metadata)
+            end
+
+            sleep interval
+            metadata.merge!(retry_count: retry_count + 1)
+          end
+
+          raise Phobos::AbortError if @listener.should_stop?
+          retry
         end
       end
 

--- a/lib/phobos/executor.rb
+++ b/lib/phobos/executor.rb
@@ -11,7 +11,7 @@ module Phobos
       start_from_beginning
       max_bytes_per_partition
       backoff
-      consume_in_batches
+      delivery
     ).freeze
 
     def initialize

--- a/lib/phobos/executor.rb
+++ b/lib/phobos/executor.rb
@@ -11,6 +11,7 @@ module Phobos
       start_from_beginning
       max_bytes_per_partition
       backoff
+      consume_in_batches
     ).freeze
 
     def initialize

--- a/spec/fixtures/batch_listener.yml
+++ b/spec/fixtures/batch_listener.yml
@@ -1,0 +1,11 @@
+logger:
+  file: log/phobos.log
+  level: fatal
+
+listeners:
+  - handler: Phobos::Handler
+    topic: test
+    start_from_beginning: true
+    group_id: test-1
+    max_concurrency: 1
+    delivery: batch

--- a/spec/fixtures/invalid_delivery_listener.yml
+++ b/spec/fixtures/invalid_delivery_listener.yml
@@ -1,0 +1,11 @@
+logger:
+  file: log/phobos.log
+  level: fatal
+
+listeners:
+  - handler: Phobos::Handler
+    topic: test
+    start_from_beginning: true
+    group_id: test-1
+    max_concurrency: 1
+    delivery: invalid

--- a/spec/fixtures/message_listener.yml
+++ b/spec/fixtures/message_listener.yml
@@ -1,0 +1,11 @@
+logger:
+  file: log/phobos.log
+  level: fatal
+
+listeners:
+  - handler: Phobos::Handler
+    topic: test
+    start_from_beginning: true
+    group_id: test-1
+    max_concurrency: 1
+    delivery: message

--- a/spec/fixtures/no_delivery_option.yml
+++ b/spec/fixtures/no_delivery_option.yml
@@ -1,0 +1,10 @@
+logger:
+  file: log/phobos.log
+  level: fatal
+
+listeners:
+  - handler: Phobos::Handler
+    topic: test
+    start_from_beginning: true
+    group_id: test-1
+    max_concurrency: 1

--- a/spec/lib/phobos/actions/process_batch_spec.rb
+++ b/spec/lib/phobos/actions/process_batch_spec.rb
@@ -27,65 +27,15 @@ RSpec.describe Phobos::Actions::ProcessBatch do
     expect(Phobos::Actions::ProcessMessage).to receive(:new).with(
       listener: listener,
       message: message1,
-      metadata: hash_including(key: 'key-1', partition: 1, offset: 2, retry_count: 0),
-      encoding: nil
+      listener_metadata: listener_metadata
     ).once.ordered.and_call_original
 
     expect(Phobos::Actions::ProcessMessage).to receive(:new).with(
       listener: listener,
       message: message2,
-      metadata: hash_including(key: 'key-2', partition: 3, offset: 4, retry_count: 0),
-      encoding: nil
+      listener_metadata: listener_metadata
     ).once.ordered.and_call_original
 
     subject.execute
-  end
-
-  context 'when processing fails' do
-    before do
-      expect(Phobos::Actions::ProcessMessage).to receive(:new).with(
-        listener: listener,
-        message: message1,
-        metadata: hash_including(key: 'key-1', partition: 1, offset: 2, retry_count: 0),
-        encoding: nil
-      ).once.ordered.and_call_original
-
-      expect(Phobos::Actions::ProcessMessage).to receive(:new).with(
-        listener: listener,
-        message: message2,
-        metadata: hash_including(key: 'key-2', partition: 3, offset: 4, retry_count: 0),
-        encoding: nil
-      ).once.ordered.and_raise('processing error')
-    end
-
-    it 'it retries failed messages' do
-      expect(Phobos::Actions::ProcessMessage).to receive(:new).with(
-        listener: listener,
-        message: message2,
-        metadata: hash_including(key: 'key-2', partition: 3, offset: 4, retry_count: 1),
-        encoding: nil
-      ).once.ordered.and_call_original
-
-      subject.execute
-    end
-
-    context 'when listener is stopping' do
-      before do
-        allow(listener).to receive(:should_stop?).and_return(true)
-      end
-
-      it 'does not retry and raises abort error' do
-        expect(Phobos::Actions::ProcessMessage).to_not receive(:new).with(
-          listener: listener,
-          message: message2,
-          metadata: hash_including(key: 'key-2', partition: 3, offset: 4, retry_count: 1),
-          encoding: nil
-        )
-
-        expect {
-          subject.execute
-        }.to raise_error(Phobos::AbortError)
-      end
-    end
   end
 end

--- a/spec/lib/phobos/cli/start_spec.rb
+++ b/spec/lib/phobos/cli/start_spec.rb
@@ -28,6 +28,32 @@ RSpec.describe Phobos::CLI::Start do
       end
     end
 
+    context 'delivery option' do
+      before do
+        allow(Phobos::CLI::Runner).to receive(:new).and_return(double('Phobos::CLI::Runner', run!: true))
+      end
+
+      it 'works with batch' do
+        start = Phobos::CLI::Start.new(config: 'spec/fixtures/batch_listener.yml', boot: 'phobos_boot.rb')
+        expect { start.execute }.to_not raise_error
+      end
+
+      it 'works with message' do
+        start = Phobos::CLI::Start.new(config: 'spec/fixtures/message_listener.yml', boot: 'phobos_boot.rb')
+        expect { start.execute }.to_not raise_error
+      end
+
+      it 'works with no delivery option' do
+        start = Phobos::CLI::Start.new(config: 'spec/fixtures/no_delivery_option.yml', boot: 'phobos_boot.rb')
+        expect { start.execute }.to_not raise_error
+      end
+
+      it 'fails with invalid option' do
+        start = Phobos::CLI::Start.new(config: 'spec/fixtures/invalid_delivery_option.yml', boot: 'phobos_boot.rb')
+        expect { start.execute }.to raise_error SystemExit
+      end
+    end
+
     it 'validates configured handlers' do
       allow(Phobos::CLI::Runner).to receive(:new).and_return(double('Phobos::CLI::Runner', run!: true))
       start = Phobos::CLI::Start.new(config: 'spec/fixtures/bad_listeners.phobos.config.yml', boot: 'phobos_boot.rb')

--- a/spec/lib/phobos/listener_spec.rb
+++ b/spec/lib/phobos/listener_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Phobos::Listener do
   let(:min_bytes) { 2 }
   let(:force_encoding) { nil }
   let(:listener_backoff) { nil }
+  let(:consume_in_batches) { true }
   let :handler_config do
     {
       handler: handler_class,
@@ -31,7 +32,8 @@ RSpec.describe Phobos::Listener do
       max_wait_time: max_wait_time,
       min_bytes: min_bytes,
       force_encoding: force_encoding,
-      backoff: listener_backoff
+      backoff: listener_backoff,
+      consume_in_batches: consume_in_batches
     }
   end
   let(:listener) { Phobos::Listener.new(handler_config) }
@@ -49,52 +51,114 @@ RSpec.describe Phobos::Listener do
     unsubscribe_all
   end
 
-  it 'calls handler with message payload, group_id and topic' do
-    now = Time.now.utc
-    Timecop.freeze(now)
+  context 'consuming in batches' do
+    before do
+      expect_any_instance_of(Kafka::Consumer)
+        .to receive(:each_batch).and_call_original
+    end
 
-    subscribe_to(*LISTENER_EVENTS) { thread }
-    wait_for_event('listener.start')
+    it 'calls handler with message payload, group_id and topic' do
+      now = Time.now.utc
+      Timecop.freeze(now)
 
-    expect(handler)
-      .to receive(:consume)
-      .with('message-1', hash_including(group_id: group_id, topic: topic, listener_id: listener.id))
-      .once { Timecop.freeze(now + 0.1) }
+      subscribe_to(*LISTENER_EVENTS) { thread }
+      wait_for_event('listener.start')
 
-    producer.publish(topic, 'message-1')
+      expect(handler)
+        .to receive(:consume)
+        .with('message-1', hash_including(group_id: group_id, topic: topic, listener_id: listener.id))
+        .once { Timecop.freeze(now + 0.1) }
 
-    wait_for_event('listener.process_message')
-    event = events_for('listener.process_message').first
-    expect(event.payload).to include(time_elapsed: 0.1)
+      producer.publish(topic, 'message-1')
 
-    wait_for_event('listener.process_batch')
-    event = events_for('listener.process_batch').first
-    expect(event.payload).to include(time_elapsed: 0.1)
+      wait_for_event('listener.process_message')
+      event = events_for('listener.process_message').first
+      expect(event.payload).to include(time_elapsed: 0.1)
 
-    listener.stop
-    wait_for_event('listener.stop')
+      wait_for_event('listener.process_batch')
+      event = events_for('listener.process_batch').first
+      expect(event.payload).to include(time_elapsed: 0.1)
+      expect(event.payload[:batch_size]).to eq(1)
+
+      listener.stop
+      wait_for_event('listener.stop')
+    end
+
+    it 'calls Phobos::Actions::ProcessBatch with the fetched Kafka batch' do
+      subscribe_to(*LISTENER_EVENTS) { thread }
+      wait_for_event('listener.start')
+
+      expect(Phobos::Actions::ProcessBatch)
+        .to receive(:new)
+        .with(
+          listener: listener,
+          batch: Kafka::FetchedBatch,
+          listener_metadata: hash_including(group_id: group_id, topic: topic, listener_id: listener.id)
+        )
+        .and_call_original
+
+      producer.async_publish(topic, 'message-1')
+      wait_for_event('listener.process_batch')
+
+      listener.stop
+      wait_for_event('listener.stop')
+
+      self.class.producer.async_producer_shutdown
+    end
   end
 
-  it 'calls Phobos::Actions::ProcessBatch with the fetched Kafka batch' do
-    subscribe_to(*LISTENER_EVENTS) { thread }
-    wait_for_event('listener.start')
+  context 'consuming individual messages' do
+    let(:consume_in_batches) { false }
 
-    expect(Phobos::Actions::ProcessBatch)
-      .to receive(:new)
-      .with(
-        listener: listener,
-        batch: Kafka::FetchedBatch,
-        listener_metadata: hash_including(group_id: group_id, topic: topic, listener_id: listener.id)
-      )
-      .and_call_original
+    before do
+      expect_any_instance_of(Kafka::Consumer)
+        .to receive(:each_message).and_call_original
+    end
 
-    producer.async_publish(topic, 'message-1')
-    wait_for_event('listener.process_batch')
+    it 'calls handler with message payload, group_id and topic' do
+      now = Time.now.utc
+      Timecop.freeze(now)
 
-    listener.stop
-    wait_for_event('listener.stop')
+      subscribe_to(*LISTENER_EVENTS) { thread }
+      wait_for_event('listener.start')
 
-    self.class.producer.async_producer_shutdown
+      expect(handler)
+        .to receive(:consume)
+        .with('message-1', hash_including(group_id: group_id, topic: topic, listener_id: listener.id))
+        .once { Timecop.freeze(now + 0.1) }
+
+      producer.publish(topic, 'message-1')
+
+      wait_for_event('listener.process_message')
+      event = events_for('listener.process_message').first
+      expect(event.payload).to include(time_elapsed: 0.1)
+      expect(event.payload[:batch_size]).to be_nil
+
+      listener.stop
+      wait_for_event('listener.stop')
+    end
+
+    it 'calls Phobos::Actions::ProcessMessage with the fetched Kafka message' do
+      subscribe_to(*LISTENER_EVENTS) { thread }
+      wait_for_event('listener.start')
+
+      expect(Phobos::Actions::ProcessMessage)
+        .to receive(:new)
+        .with(
+          listener: listener,
+          message: Kafka::FetchedMessage,
+          listener_metadata: hash_including(group_id: group_id, topic: topic, listener_id: listener.id)
+        )
+        .and_call_original
+
+      producer.async_publish(topic, 'message-1')
+      wait_for_event('listener.process_message')
+
+      listener.stop
+      wait_for_event('listener.stop')
+
+      self.class.producer.async_producer_shutdown
+    end
   end
 
   it 'calls consumer with max_wait_time and min_bytes' do
@@ -236,7 +300,7 @@ RSpec.describe Phobos::Listener do
     end
 
     it "gracefully exits when Phobos::AbortError happens" do
-      expect_any_instance_of(Phobos::Actions::ProcessBatch)
+      expect_any_instance_of(Phobos::Actions::ProcessMessage)
         .to receive(:execute)
         .once
         .and_raise(Phobos::AbortError, 'Phobos aborting')
@@ -255,7 +319,7 @@ RSpec.describe Phobos::Listener do
     end
 
     it "gracefully exits when Kafka::ProcessingError happens" do
-      expect_any_instance_of(Phobos::Actions::ProcessBatch)
+      expect_any_instance_of(Phobos::Actions::ProcessMessage)
         .to receive(:execute)
         .once
         .and_raise(Kafka::ProcessingError.new('foo', 1, 2), 'Kafka aborting')

--- a/spec/lib/phobos/listener_spec.rb
+++ b/spec/lib/phobos/listener_spec.rb
@@ -173,25 +173,55 @@ RSpec.describe Phobos::Listener do
 
   context 'when min_bytes is not set' do
     let(:min_bytes) { nil }
+    let(:consumer) { listener.send(:create_kafka_consumer) }
 
-    it 'does not pass min_bytes to consumer' do
-      consumer = listener.send(:create_kafka_consumer)
+    before do
       expect(listener).to receive(:create_kafka_consumer).and_return(consumer)
-      expect(consumer).to receive(:each_batch).with(hash_excluding(:min_bytes)).and_call_original
+    end
 
-      consume_and_stop
+    context 'batches' do
+      let(:consume_in_batches) { true }
+
+      it 'does not pass min_bytes to consumer' do
+        expect(consumer).to receive(:each_batch).with(hash_excluding(:min_bytes)).and_call_original
+        consume_and_stop
+      end
+    end
+
+    context 'individual messages' do
+      let(:consume_in_batches) { false }
+
+      it 'does not pass min_bytes to consumer' do
+        expect(consumer).to receive(:each_message).with(hash_excluding(:min_bytes)).and_call_original
+        consume_and_stop
+      end
     end
   end
 
   context 'when max_wait_time is not set' do
     let(:max_wait_time) { nil }
+    let(:consumer) { listener.send(:create_kafka_consumer) }
 
-    it 'does not pass max_wait_time to consumer' do
-      consumer = listener.send(:create_kafka_consumer)
+    before do
       expect(listener).to receive(:create_kafka_consumer).and_return(consumer)
-      expect(consumer).to receive(:each_batch).with(hash_excluding(:max_wait_time)).and_call_original
+    end
 
-      consume_and_stop
+    context 'batches' do
+      let(:consume_in_batches) { true }
+
+      it 'does not pass max_wait_time to consumer' do
+        expect(consumer).to receive(:each_batch).with(hash_excluding(:max_wait_time)).and_call_original
+        consume_and_stop
+      end
+    end
+
+    context 'individual messages' do
+      let(:consume_in_batches) { false }
+
+      it 'does not pass max_wait_time to consumer' do
+        expect(consumer).to receive(:each_message).with(hash_excluding(:max_wait_time)).and_call_original
+        consume_and_stop
+      end
     end
   end
 
@@ -412,7 +442,7 @@ RSpec.describe Phobos::Listener do
     wait_for_event('listener.start')
 
     producer.publish(topic, 'message-1')
-    wait_for_event('listener.process_batch')
+    wait_for_event('listener.process_message')
 
     listener.stop
     wait_for_event('listener.stop')

--- a/spec/lib/phobos/listener_spec.rb
+++ b/spec/lib/phobos/listener_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Phobos::Listener do
   let(:min_bytes) { 2 }
   let(:force_encoding) { nil }
   let(:listener_backoff) { nil }
-  let(:consume_in_batches) { true }
+  let(:delivery) { 'batch' }
   let :handler_config do
     {
       handler: handler_class,
@@ -33,7 +33,7 @@ RSpec.describe Phobos::Listener do
       min_bytes: min_bytes,
       force_encoding: force_encoding,
       backoff: listener_backoff,
-      consume_in_batches: consume_in_batches
+      delivery: delivery
     }
   end
   let(:listener) { Phobos::Listener.new(handler_config) }
@@ -108,7 +108,7 @@ RSpec.describe Phobos::Listener do
   end
 
   context 'consuming individual messages' do
-    let(:consume_in_batches) { false }
+    let(:delivery) { 'message' }
 
     before do
       expect_any_instance_of(Kafka::Consumer)
@@ -180,7 +180,7 @@ RSpec.describe Phobos::Listener do
     end
 
     context 'batches' do
-      let(:consume_in_batches) { true }
+      let(:delivery) { 'batch' }
 
       it 'does not pass min_bytes to consumer' do
         expect(consumer).to receive(:each_batch).with(hash_excluding(:min_bytes)).and_call_original
@@ -189,7 +189,7 @@ RSpec.describe Phobos::Listener do
     end
 
     context 'individual messages' do
-      let(:consume_in_batches) { false }
+      let(:delivery) { 'message' }
 
       it 'does not pass min_bytes to consumer' do
         expect(consumer).to receive(:each_message).with(hash_excluding(:min_bytes)).and_call_original
@@ -207,7 +207,7 @@ RSpec.describe Phobos::Listener do
     end
 
     context 'batches' do
-      let(:consume_in_batches) { true }
+      let(:delivery) { 'batch' }
 
       it 'does not pass max_wait_time to consumer' do
         expect(consumer).to receive(:each_batch).with(hash_excluding(:max_wait_time)).and_call_original
@@ -216,7 +216,7 @@ RSpec.describe Phobos::Listener do
     end
 
     context 'individual messages' do
-      let(:consume_in_batches) { false }
+      let(:delivery) { 'message' }
 
       it 'does not pass max_wait_time to consumer' do
         expect(consumer).to receive(:each_message).with(hash_excluding(:max_wait_time)).and_call_original


### PR DESCRIPTION
Addressing https://github.com/klarna/phobos/issues/21

I found that in production that I need to process using `each_message` for certain listeners. This PR adds that ability via the `consume_in_batches` listener option. I had to move some code around to accomplish this, but I think everything looks good.

A couple
1.) I added specs, but let me know if they are sufficient enough.
2.) I'm open to any configuration / naming changes