### PR TITLE
Load boot file before configuration file

### DIFF
--- a/lib/phobos/cli/start.rb
+++ b/lib/phobos/cli/start.rb
@@ -15,12 +15,12 @@ module Phobos
       end
 
       def execute
+        load_boot_file
+
         if config_file
           validate_config_file!
           Phobos.configure(config_file)
         end
-
-        load_boot_file
 
         if listeners_file
           Phobos.add_listeners(listeners_file)


### PR DESCRIPTION
I think it may be nice to load the boot file before configuring phobos. This way any code loaded inside of the boot file can be referenced via ERB inside of `config.yml`. WDYT?