### PR TITLE
Add support for formatting log for stdout as json

### DIFF
--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -1,8 +1,9 @@
 logger:
   # Optional log file, set to false or remove to disable it
   file: log/phobos.log
-  # Optional log format for stdout, remove to use human readable format
-  stdout_format: json
+  # Optional output format for stdout, default is false (human readable).
+  # Set to true to enable json output.
+  stdout_json: false
   level: info
   # Comment the block to disable ruby-kafka logs
   ruby_kafka:

--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -1,6 +1,8 @@
 logger:
   # Optional log file, set to false or remove to disable it
   file: log/phobos.log
+  # Optional log format for stdout, remove to use human readable format
+  stdout_format: json
   level: info
   # Comment the block to disable ruby-kafka logs
   ruby_kafka:

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -62,7 +62,7 @@ module Phobos
       date_pattern = '%Y-%m-%dT%H:%M:%S:%L%zZ'
       json_layout = Logging.layouts.json(date_pattern: date_pattern)
 
-      stdout_layout = if config.logger.stdout_format&.to_sym == :json
+      stdout_layout = if config.logger.stdout_json == true
         json_layout
       else
         Logging.layouts.pattern(date_pattern: date_pattern)

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -60,8 +60,14 @@ module Phobos
       log_file = config.logger.file
       ruby_kafka = config.logger.ruby_kafka
       date_pattern = '%Y-%m-%dT%H:%M:%S:%L%zZ'
-      file_layout = Logging.layouts.json(date_pattern: date_pattern)
-      stdout_layout = Logging.layouts.pattern(date_pattern: date_pattern)
+      json_layout = Logging.layouts.json(date_pattern: date_pattern)
+
+      stdout_layout = if config.logger.stdout_format&.to_sym == :json
+        json_layout
+      else
+        Logging.layouts.pattern(date_pattern: date_pattern)
+      end
+
       appenders = [Logging.appenders.stdout(layout: stdout_layout)]
 
       Logging.backtrace(true)
@@ -69,7 +75,7 @@ module Phobos
 
       if log_file
         FileUtils.mkdir_p(File.dirname(log_file))
-        appenders << Logging.appenders.file(log_file, layout: file_layout)
+        appenders << Logging.appenders.file(log_file, layout: json_layout)
       end
 
       @ruby_kafka_logger = nil

--- a/spec/lib/phobos/cli_spec.rb
+++ b/spec/lib/phobos/cli_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Phobos::CLI do
 
   describe '$ phobos' do
     it 'prints help text' do
-      output = capture(:stdout) { Phobos::CLI::Commands.start([]) }
+      output = capture_stdout { Phobos::CLI::Commands.start([]) }
       expect(output).to include 'help [COMMAND]  # Describe available commands or one specific command'
     end
   end

--- a/spec/lib/phobos_spec.rb
+++ b/spec/lib/phobos_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Phobos do
   describe '.logger' do
     before do
       STDOUT.sync = true
-      Phobos.silence_log = false
+      allow(Phobos).to receive(:silence_log).and_return(false)
     end
 
     context 'without a file configured' do

--- a/spec/lib/phobos_spec.rb
+++ b/spec/lib/phobos_spec.rb
@@ -103,26 +103,60 @@ RSpec.describe Phobos do
   end
 
   describe '.logger' do
-    before do
-      STDOUT.sync = true
-      allow(Phobos).to receive(:silence_log).and_return(false)
+    let(:stdout_appender) do
+      Logging.logger[Phobos].appenders.grep(Logging::Appenders::Stdout).first
+    end
+    let(:file_appender) do
+      Logging.logger[Phobos].appenders.grep(Logging::Appenders::File).first
     end
 
-    context 'without a file configured' do
-      it 'writes only to STDOUT' do
-        Phobos.config.logger.file = nil
-        expect { Phobos.configure_logger }.to_not raise_error
+    it 'outputs human readable format to stdout' do
+      expect(stdout_appender.layout).to be_a(Logging::Layouts::Pattern)
+      expect(stdout_appender.layout.instance_variable_get(:@pattern)).to eq "[%d] %-5l -- %c : %m\n"
+      expect(stdout_appender.layout.instance_variable_get(:@obj_format)).to eq :string
+    end
 
-        output = capture(:stdout) { Phobos.logger.info('log-to-stdout') }
-        expect(output).to eql output
+    it 'outputs json format to file' do
+      expect(file_appender.layout).to be_a(Logging::Layouts::Parseable)
+      expect(file_appender.layout.instance_variable_get(:@style)).to eq :json
+    end
+
+    context 'when stdout_json is true' do
+      before :each do
+        Phobos.config.logger.stdout_json = true
+        Phobos.configure_logger
+      end
+
+      after :each do
+        Phobos.config.logger.stdout_json = false
+        Phobos.configure_logger
+      end
+
+      it 'outputs json format to stdout' do
+        expect(stdout_appender.layout).to be_a(Logging::Layouts::Parseable)
+        expect(stdout_appender.layout.instance_variable_get(:@style)).to eq :json
+      end
+
+      it 'outputs json format to file' do
+        expect(file_appender.layout).to be_a(Logging::Layouts::Parseable)
+        expect(file_appender.layout.instance_variable_get(:@style)).to eq :json
       end
     end
 
-    context 'with "config.logger.file" defined' do
-      it 'writes to the logger file' do
+    context 'file' do
+      before :each do
+        allow(Phobos).to receive(:silence_log).and_return(false)
+        @old_file = Phobos.config.logger.file
         Phobos.config.logger.file = 'spec/spec.log'
-        expect { Phobos.configure_logger }.to_not raise_error
+        Phobos.configure_logger
+      end
 
+      after :each do
+        Phobos.config.logger.file = @old_file
+        Phobos.configure_logger
+      end
+
+      it 'writes to the logger file' do
         Phobos.logger.info('log-to-file')
         expect(File.read('spec/spec.log')).to match /log-to-file/
         File.delete(Phobos.config.logger.file)

--- a/spec/support/cli_helpers.rb
+++ b/spec/support/cli_helpers.rb
@@ -1,12 +1,12 @@
 module CLIHelpers
-  def capture(stream)
+  def capture_stdout
     begin
-      stream = stream.to_s
-      eval "$#{stream} = StringIO.new"
+      stream = $stdout
+      $stdout = StringIO.new
       yield
-      result = eval("$#{stream}").string
+      result = $stdout.string
     ensure
-      eval("$#{stream} = #{stream.upcase}")
+      $stdout = stream
     end
 
     result


### PR DESCRIPTION
When running a phobos project inside a docker container, it would be nice to capture stdout as json, so splunk has a good time parsing the phobos logs.