### PR TITLE
Change default max bytes per partition to 1 MB

### DIFF
--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -3,7 +3,7 @@ module Phobos
     include Phobos::Instrumentation
 
     KAFKA_CONSUMER_OPTS = %i(session_timeout offset_commit_interval offset_commit_threshold heartbeat_interval).freeze
-    DEFAULT_MAX_BYTES_PER_PARTITION = 524288 # 512 KB
+    DEFAULT_MAX_BYTES_PER_PARTITION = 1048576 # 1 MB
     DELIVERY_OPTS = %w[batch message].freeze
 
     attr_reader :group_id, :topic, :id


### PR DESCRIPTION
See https://github.com/klarna/phobos/issues/44

Change `DEFAULT_MAX_BYTES_PER_PARTITION` to match the `ruby-kafka` default. https://github.com/zendesk/ruby-kafka/blob/84986d08bf2c27af006fb3006ec0f0b4e89b91b2/lib/kafka/consumer.rb#L91

The new value will be around 1MB, which is the same size as the default broker configuration value of `max.message.bytes`.