### PR TITLE
Change activesupport dependency from 4 to 3

### DIFF
--- a/lib/phobos/cli.rb
+++ b/lib/phobos/cli.rb
@@ -41,21 +41,21 @@ module Phobos
       end
 
       desc 'start', 'Starts Phobos'
-      option :config,
-             aliases: ['-c'],
-             default: 'config/phobos.yml',
-             banner: 'Configuration file'
-      option :boot,
-             aliases: ['-b'],
-             banner: 'File path to load application specific code',
-             default: 'phobos_boot.rb'
-      option :listeners,
-             aliases: ['-l'],
-             banner: 'Separate listeners config file (optional)'
-      option :skip_config,
-             default: false,
-             type: :boolean,
-             banner: 'Skip config file'
+      method_option :config,
+                    aliases: ['-c'],
+                    default: 'config/phobos.yml',
+                    banner: 'Configuration file'
+      method_option :boot,
+                    aliases: ['-b'],
+                    banner: 'File path to load application specific code',
+                    default: 'phobos_boot.rb'
+      method_option :listeners,
+                    aliases: ['-l'],
+                    banner: 'Separate listeners config file (optional)'
+      method_option :skip_config,
+                    default: false,
+                    type: :boolean,
+                    banner: 'Skip config file'
       def start
         Phobos::CLI::Start.new(options).execute
       end

--- a/phobos.gemspec
+++ b/phobos.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ruby-kafka', '>= 0.3.14'
   spec.add_dependency 'concurrent-ruby', '>= 1.0.2'
   spec.add_dependency 'concurrent-ruby-ext', '>= 1.0.2'
-  spec.add_dependency 'activesupport', '>= 4.0.0'
+  spec.add_dependency 'activesupport', '>= 3.0.0'
   spec.add_dependency 'logging'
   spec.add_dependency 'exponential-backoff'
   spec.add_dependency 'thor'


### PR DESCRIPTION
Hi,

I was able to run this locally with ruby 2.3.4 and Rails 3.0.5.

Had to modify the CLI to use `method_option`, because `option` wasn't working.

Let me know if you need anything else.

Thanks