### PR TITLE
Instrument handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Test are failing with ruby-kafka 0.5.0 #48
 - Allow Phobos to run in apps using ActiveSupport 3.x #57
 ### Added
-- Property handler added to listener instrumentation
+- Property (handler) added to listener instrumentation
 ### Removed
 - Property (time_elapsed) removed #24 - use duration instead
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Test are failing with ruby-kafka 0.5.0 #48
 - Allow Phobos to run in apps using ActiveSupport 3.x #57
+### Added
+- Property handler added to listener instrumentation
 ### Removed
 - Property (time_elapsed) removed #24 - use duration instead
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Test are failing with ruby-kafka 0.5.0 #48
 - Allow Phobos to run in apps using ActiveSupport 3.x #57
+### Removed
+- Property (time_elapsed) removed #24 - use duration instead
 
 ## [1.6.1] - 2017-11-16
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -390,7 +390,6 @@ end
     * partition
     * offset_lag
     * highwater_mark_offset
-    * time_elapsed
   * `listener.process_message` is sent after process a message. It includes the following payload:
     * listener_id
     * group_id
@@ -399,7 +398,6 @@ end
     * partition
     * offset
     * retry_count
-    * time_elapsed
   * `listener.retry_handler_error` is sent after waited for `handler#consume` retry. It includes the following payload:
     * listener_id
     * group_id

--- a/README.md
+++ b/README.md
@@ -378,14 +378,17 @@ end
     * listener_id
     * group_id
     * topic
+    * handler
   * `listener.start` is sent when listener starts. It includes the following payload:
     * listener_id
     * group_id
     * topic
+    * handler
   * `listener.process_batch` is sent after process a batch. It includes the following payload:
     * listener_id
     * group_id
     * topic
+    * handler
     * batch_size
     * partition
     * offset_lag
@@ -394,6 +397,7 @@ end
     * listener_id
     * group_id
     * topic
+    * handler
     * key
     * partition
     * offset
@@ -402,6 +406,7 @@ end
     * listener_id
     * group_id
     * topic
+    * handler
     * key
     * partition
     * offset
@@ -414,18 +419,22 @@ end
     * listener_id
     * group_id
     * topic
+    * handler
   * `listener.stopping` is sent when the listener receives signal to stop
     * listener_id
     * group_id
     * topic
+    * handler
   * `listener.stop_handler` is sent after stopping the handler
     * listener_id
     * group_id
     * topic
+    * handler
   * `listener.stop` is send after stopping the listener
     * listener_id
     * group_id
     * topic
+    * handler
 
 ## <a name="plugins"></a> Plugins
 

--- a/lib/phobos/actions/process_batch.rb
+++ b/lib/phobos/actions/process_batch.rb
@@ -18,17 +18,13 @@ module Phobos
 
       def execute
         instrument('listener.process_batch', @metadata) do |metadata|
-          time_elapsed = measure do
-            @batch.messages.each do |message|
-              Phobos::Actions::ProcessMessage.new(
-                listener: @listener,
-                message: message,
-                listener_metadata: @listener_metadata
-              ).execute
-            end
+          @batch.messages.each do |message|
+            Phobos::Actions::ProcessMessage.new(
+              listener: @listener,
+              message: message,
+              listener_metadata: @listener_metadata
+            ).execute
           end
-
-          metadata.merge!(time_elapsed: time_elapsed)
         end
       end
     end

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -56,20 +56,13 @@ module Phobos
       end
 
       def process_message(payload)
-        instrument('listener.process_message', @metadata) do |metadata|
-          consume_result = nil
-          time_elapsed = measure do
-            handler = @listener.handler_class.new
-            preprocessed_payload = handler.before_consume(payload)
+        instrument('listener.process_message', @metadata) do
+          handler = @listener.handler_class.new
+          preprocessed_payload = handler.before_consume(payload)
 
-            @listener.handler_class.around_consume(preprocessed_payload, @metadata) do
-              consume_result = handler.consume(preprocessed_payload, @metadata)
-            end
+          @listener.handler_class.around_consume(preprocessed_payload, @metadata) do
+            handler.consume(preprocessed_payload, @metadata)
           end
-
-          metadata.merge!(time_elapsed: time_elapsed)
-
-          consume_result
         end
       end
     end

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -8,7 +8,6 @@ module Phobos
       def initialize(listener:, message:, listener_metadata:)
         @listener = listener
         @message = message
-        @listener_metadata = listener_metadata
         @metadata = listener_metadata.merge(
           key: message.key,
           partition: message.partition,

--- a/lib/phobos/instrumentation.rb
+++ b/lib/phobos/instrumentation.rb
@@ -17,11 +17,5 @@ module Phobos
         yield(extra) if block_given?
       end
     end
-
-    def measure
-      start = Time.now.utc
-      yield if block_given?
-      (Time.now.utc - start).round(3)
-    end
   end
 end

--- a/lib/phobos/instrumentation.rb
+++ b/lib/phobos/instrumentation.rb
@@ -1,3 +1,5 @@
+require 'active_support/notifications'
+
 module Phobos
   module Instrumentation
     NAMESPACE = 'phobos'

--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -124,7 +124,7 @@ module Phobos
     private
 
     def listener_metadata
-      { listener_id: id, group_id: group_id, topic: topic }
+      { listener_id: id, group_id: group_id, topic: topic, handler: handler_class.to_s }
     end
 
     def create_kafka_consumer

--- a/spec/lib/phobos/listener_spec.rb
+++ b/spec/lib/phobos/listener_spec.rb
@@ -73,11 +73,11 @@ RSpec.describe Phobos::Listener do
 
       wait_for_event('listener.process_message')
       event = events_for('listener.process_message').first
-      expect(event.payload).to include(time_elapsed: 0.1)
+      expect(event.duration).to eq 100.0
 
       wait_for_event('listener.process_batch')
       event = events_for('listener.process_batch').first
-      expect(event.payload).to include(time_elapsed: 0.1)
+      expect(event.duration).to eq 100.0
       expect(event.payload[:batch_size]).to eq(1)
 
       listener.stop
@@ -131,7 +131,7 @@ RSpec.describe Phobos::Listener do
 
       wait_for_event('listener.process_message')
       event = events_for('listener.process_message').first
-      expect(event.payload).to include(time_elapsed: 0.1)
+      expect(event.duration).to eq 100.0
       expect(event.payload[:batch_size]).to be_nil
 
       listener.stop


### PR DESCRIPTION
Add `handler` to the instrumentation payload for listener events.

Remove `time_elapsed` (seconds) in instrumentation payload, in favor of using the `duration` (ms) method on the active support instrumentation event instead. This simplifies our code a bit.