### PR TITLE
Ruby 2.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 language: ruby
 rvm:
   - 2.4.1
+  - 2.3.6
 
 services:
   - docker


### PR DESCRIPTION
Many deployments are still on "older" rubies. This ensures that both officially supported versions are working.