### PR TITLE
Add offset_retention_time to consumer options

### DIFF
--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -70,6 +70,8 @@ consumer:
   # number of messages that can be processed before their offsets are committed.
   # If zero, offset commits are not triggered by message processing
   offset_commit_threshold: 0
+  # the time period that committed offsets will be retained, in seconds. Defaults to the broker setting.
+  offset_retention_time:
   # interval between heartbeats; must be less than the session window
   heartbeat_interval: 10
 

--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -2,7 +2,14 @@ module Phobos
   class Listener
     include Phobos::Instrumentation
 
-    KAFKA_CONSUMER_OPTS = %i(session_timeout offset_commit_interval offset_commit_threshold heartbeat_interval).freeze
+    KAFKA_CONSUMER_OPTS = %i(
+      session_timeout
+      offset_commit_interval
+      offset_commit_threshold
+      heartbeat_interval
+      offset_retention_time
+    ).freeze
+
     DEFAULT_MAX_BYTES_PER_PARTITION = 1048576 # 1 MB
     DELIVERY_OPTS = %w[batch message].freeze
 


### PR DESCRIPTION
`ruby-kafka` exposes offset retention time setting to the consumer API. This setting allows a custom offset retention time period per kafka consumer group.

From the `ruby-kafka` README

> Stale offsets are periodically purged by the broker. The broker setting offsets.retention.minutes controls the retention window for committed offsets, and defaults to 1 day. The length of the retention window, known as offset retention time, can be changed for the consumer.

See: https://github.com/zendesk/ruby-kafka/pull/316