### PR TITLE
Force encoding a null Kafka message.value

### DIFF
--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -51,7 +51,7 @@ module Phobos
       private
 
       def force_encoding(value)
-        @listener.encoding ? value.force_encoding(@listener.encoding) : value
+        @listener.encoding ? value&.force_encoding(@listener.encoding) : value
       end
 
       def process_message(payload)

--- a/spec/lib/phobos/actions/process_message_spec.rb
+++ b/spec/lib/phobos/actions/process_message_spec.rb
@@ -69,6 +69,18 @@ RSpec.describe Phobos::Actions::ProcessMessage do
         ).execute
       end
     end
+
+    it "passes on messages with no content untouched" do
+      expect(handler).to receive(:consume) do |handler_payload, _|
+        expect(handler_payload).to be nil
+      end
+
+      described_class.new(
+        listener: listener,
+        message: OpenStruct.new(value: nil),
+        listener_metadata: metadata
+      ).execute
+    end
   end
 
   context 'when processing fails' do


### PR DESCRIPTION
Fixes #63, an interaction between the `force_encoding` option and empty Kafka messages.