### PR TITLE
Phobos overwrites ENV['RAILS_ENV'] with incorrect value.

### DIFF
--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -31,13 +31,12 @@ module Phobos
     attr_accessor :silence_log
 
     def configure(configuration)
-      ENV['RAILS_ENV'] = ENV['RACK_ENV'] ||= 'development'
       @config = DeepStruct.new(fetch_settings(configuration))
       @config.class.send(:define_method, :producer_hash) { Phobos.config.producer&.to_hash }
       @config.class.send(:define_method, :consumer_hash) { Phobos.config.consumer&.to_hash }
       @config.listeners ||= []
       configure_logger
-      logger.info { Hash(message: 'Phobos configured', env: ENV['RACK_ENV']) }
+      logger.info { Hash(message: 'Phobos configured', env: ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'N/A') }
     end
 
     def add_listeners(listeners_configuration)


### PR DESCRIPTION
Do not set `ENV['RAILS_ENV']` or `ENV['RACK_ENV']` (see [lib/phobos.rb#L34](https://github.com/klarna/phobos/blob/v1.7.0/lib/phobos.rb#L34)).  It appears this is only used for logging purposes, and if `ENV['RAILS_ENV']` is set but `ENV['RACK_ENV']` is unset it results in `ENV['RAILS_ENV']` being set to `'development'`.  Neither of these should be set by this library.
