### PR TITLE
Allow listeners to overwrite consumer opts

### DIFF
--- a/config/phobos.yml.example
+++ b/config/phobos.yml.example
@@ -114,3 +114,10 @@ listeners:
     backoff:
       min_ms: 500
       max_ms: 10000
+    # session_timeout, offset_commit_interval, offset_commit_threshold, offset_retention_time, and heartbeat_interval
+    # can be customized per listener if desired
+    session_timeout: 30
+    offset_commit_interval: 15
+    offset_commit_threshold: 5
+    offset_retention_time: 172800
+    heartbeat_interval: 20

--- a/lib/phobos/executor.rb
+++ b/lib/phobos/executor.rb
@@ -12,6 +12,11 @@ module Phobos
       max_bytes_per_partition
       backoff
       delivery
+      session_timeout
+      offset_commit_interval
+      offset_commit_threshold
+      heartbeat_interval
+      offset_retention_time
     ).freeze
 
     def initialize


### PR DESCRIPTION
Provides the ability to override `session_timeout`, `heartbeat_interval`, `offset_retention_time`, `offset_commit_interval`, and `offset_commit_threshold` per listener.

For example, it might be desirable to relax the `offset_commit_interval` / `offset_commit_threshold` for listeners that are idempotent.