### PR TITLE
Reduce the volume of info-level log messages

### DIFF
--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -103,7 +103,7 @@ module Phobos
         )
 
         batch_processor.execute
-        Phobos.logger.info { Hash(message: 'Committed offset').merge(batch_processor.metadata) }
+        Phobos.logger.debug { Hash(message: 'Committed offset').merge(batch_processor.metadata) }
         return if should_stop?
       end
     end
@@ -117,7 +117,7 @@ module Phobos
         )
 
         message_processor.execute
-        Phobos.logger.info { Hash(message: 'Committed offset').merge(message_processor.metadata) }
+        Phobos.logger.debug { Hash(message: 'Committed offset').merge(message_processor.metadata) }
         return if should_stop?
       end
     end


### PR DESCRIPTION
Per message/batch logging at info level can be too overwhelming.  Downgrade to debug level, to separate them from other valuable info level log messages for configure/start/stop, etc.