### PR TITLE
Send heartbeat while retrying on processing errors

### DIFF
--- a/lib/phobos/listener.rb
+++ b/lib/phobos/listener.rb
@@ -139,6 +139,11 @@ module Phobos
       @signal_to_stop == true
     end
 
+    def send_heartbeat_if_necessary
+      return if should_stop?
+      @consumer&.try(:send_heartbeat_if_necessary)
+    end
+
     private
 
     def listener_metadata


### PR DESCRIPTION
Also, break down big retry backoff into smaller sleep intervals, in order to send heartbeat in time and faster detection of listerner stop.