### PR TITLE
Allow a custom logger for both Phobos and RubyKafka.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## UNRELEASED
 ### Changed
 - Reduce the volume of info-level log messages #78
+- Add ability to configure a custom logger #81
 
 ## [1.7.2] - 2018-05-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -320,17 +320,24 @@ The configuration file is organized in 6 sections. Take a look at the example fi
 
 The file will be parsed through ERB so ERB syntax/file extension is supported beside the YML format.
 
-__logger__ configures the logger for all Phobos components, it automatically outputs to `STDOUT` and it saves the log in the configured file
+__logger__ configures the logger for all Phobos components. It automatically 
+outputs to `STDOUT` and it saves the log in the configured file.
 
-__kafka__ provides configurations for every `Kafka::Client` created over the application. All [options supported by  `ruby-kafka`][ruby-kafka-client] can be provided.
+__kafka__ provides configurations for every `Kafka::Client` created over the application. 
+All [options supported by  `ruby-kafka`][ruby-kafka-client] can be provided.
 
-__producer__ provides configurations for all producers created over the application, the options are the same for regular and async producers. All [options supported by  `ruby-kafka`][ruby-kafka-producer] can be provided.
+__producer__ provides configurations for all producers created over the application, 
+the options are the same for regular and async producers. 
+All [options supported by  `ruby-kafka`][ruby-kafka-producer] can be provided.
 
-__consumer__ provides configurations for all consumer groups created over the application. All [options supported by  `ruby-kafka`][ruby-kafka-consumer] can be provided.
+__consumer__ provides configurations for all consumer groups created over the application. 
+All [options supported by  `ruby-kafka`][ruby-kafka-consumer] can be provided.
 
-__backoff__ Phobos provides automatic retries for your handlers, if an exception is raised the listener will retry following the back off configured here. Backoff can also be configured per listener.
+__backoff__ Phobos provides automatic retries for your handlers. If an exception 
+is raised, the listener will retry following the back off configured here. 
+Backoff can also be configured per listener.
 
-__listeners__ is the list of listeners configured, each listener represents a consumers group
+__listeners__ is the list of listeners configured. Each listener represents a consumer group.
 
 [ruby-kafka-client]: http://www.rubydoc.info/gems/ruby-kafka/Kafka%2FClient%3Ainitialize
 [ruby-kafka-consumer]: http://www.rubydoc.info/gems/ruby-kafka/Kafka%2FClient%3Aconsumer
@@ -349,6 +356,23 @@ $ phobos start -c /var/configs/my.yml -l /var/configs/additional_listeners.yml
 
 Note that the config file _must_ still specify a listeners section, though it
 can be empty.
+
+#### Custom configuration/logging
+
+Phobos can be configured using a hash rather than the config file directly. This
+can be useful if you want to do some pre-processing before sending the file
+to Phobos. One particularly useful aspect is the ability to provide Phobos
+with a custom logger, e.g. by reusing the Rails logger:
+
+```ruby
+Phobos.configure(
+  custom_logger: Rails.logger,
+  custom_kafka_logger: Rails.logger
+)
+```
+
+If these keys are given, they will override the `logger` keys in the Phobos
+config file.
 
 ### <a name="usage-instrumentation"></a> Instrumentation
 

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -65,18 +65,16 @@ module Phobos
 
       @ruby_kafka_logger = nil
 
-      custom_kafka_logger = config.custom_kafka_logger
-      if custom_kafka_logger
-        @ruby_kafka_logger = custom_kafka_logger
+      if config.custom_kafka_logger
+        @ruby_kafka_logger = config.custom_kafka_logger
       elsif ruby_kafka
         @ruby_kafka_logger = Logging.logger['RubyKafka']
         @ruby_kafka_logger.appenders = appenders
         @ruby_kafka_logger.level = silence_log ? :fatal : ruby_kafka.level
       end
 
-      custom_logger = config.custom_logger
-      if custom_logger
-        @logger = custom_logger
+      if config.custom_logger
+        @logger = config.custom_logger
       else
         @logger = Logging.logger[self]
         @logger.appenders = appenders

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -78,9 +78,11 @@ module Phobos
         appenders << Logging.appenders.file(log_file, layout: json_layout)
       end
 
-      @ruby_kafka_logger = config.custom_kafka_logger
+      @ruby_kafka_logger = nil
 
-      if ruby_kafka && @ruby_kafka_logger.nil?
+      if config.custom_kafka_logger
+        @ruby_kafka_logger = config.custom_kafka_logger
+      elsif ruby_kafka
         @ruby_kafka_logger = Logging.logger['RubyKafka']
         @ruby_kafka_logger.appenders = appenders
         @ruby_kafka_logger.level = silence_log ? :fatal : ruby_kafka.level

--- a/spec/lib/phobos_spec.rb
+++ b/spec/lib/phobos_spec.rb
@@ -33,6 +33,32 @@ RSpec.describe Phobos do
         expect(Phobos.config.kafka.client_id).to eq('client_id')
         expect(Phobos.config.logger.file).to eq('log/phobos.log')
       end
+
+      it 'sets custom loggers' do
+        logger = Logger.new(STDOUT)
+        kafka_logger = Logger.new(STDOUT)
+        configuration_settings = {
+          kafka: { client_id: 'client_id' },
+          logger: { file: 'log/phobos.log' },
+          custom_logger: logger,
+          custom_kafka_logger: kafka_logger
+        }
+
+        Phobos.instance_variable_set(:@config, nil)
+        Phobos.configure(configuration_settings)
+
+        expect(Phobos.config).to_not be_nil
+        expect(Phobos.config.kafka.client_id).to eq('client_id')
+        expect(Phobos.logger).to eq(logger)
+
+        expect(Kafka).to receive(:new).with(
+          {
+            client_id: 'client_id',
+            logger: kafka_logger
+          })
+        Phobos.create_kafka_client
+      end
+
     end
   end
 


### PR DESCRIPTION
I have a custom Rails logger I'm using which uses ActiveSupport tagged logging and not the `Logging` framework. This PR allows me to set the custom logger to Phobos instead of being required to use Logging.