### PR TITLE
Around consume instance method

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Finally, it is also possible to preprocess the message payload before consuming 
 class MyHandler
   include Phobos::Handler
 
-  def before_consume(payload)
+  def before_consume(payload, metadata)
     # optionally preprocess payload
     payload
   end
@@ -525,7 +525,7 @@ describe MyConsumer do
 
   it 'consumes my message' do
     expect_any_instance_of(described_class).to receive(:around_consume).with(payload, metadata).once.and_call_original
-    expect_any_instance_of(described_class).to receive(:before_consume).with(payload).once.and_call_original
+    expect_any_instance_of(described_class).to receive(:before_consume).with(payload, metadata).once.and_call_original
     expect_any_instance_of(described_class).to receive(:consume).with(payload, metadata).once.and_call_original
 
     process_message(handler: described_class, payload: payload, metadata: metadata)

--- a/README.md
+++ b/README.md
@@ -156,7 +156,25 @@ class MyHandler
 end
 ```
 
-It is also possible to control the execution of `#consume` with the class method `.around_consume(payload, metadata)`. This method receives the payload and metadata, and then invokes `#consume` method by means of a block; example:
+It is also possible to control the execution of `#consume` with the method `#around_consume(payload, metadata)`. This method receives the payload and metadata, and then invokes `#consume` method by means of a block; example:
+
+```ruby
+class MyHandler
+  include Phobos::Handler
+
+  def around_consume(payload, metadata)
+    Phobos.logger.info "consuming..."
+    output = yield
+    Phobos.logger.info "done, output: #{output}"
+  end
+
+  def consume(payload, metadata)
+    # consume or skip message
+  end
+end
+```
+
+Note: `around_consume` can also be defined as a class method. If defined, the class method `.around_consume` takes precedence.
 
 ```ruby
 class MyHandler
@@ -174,7 +192,7 @@ class MyHandler
 end
 ```
 
-Finally, it is also possible to preprocess the message payload before consuming it using the `before_consume` hook which is invoked before `.around_consume` and `#consume`. The result of this operation will be assigned to payload, so it is important to return the modified payload. This can be very useful, for example if you want a single point of decoding Avro messages and want the payload as a hash instead of a binary.
+Finally, it is also possible to preprocess the message payload before consuming it using the `before_consume` hook which is invoked before `#around_consume` and `#consume`. The result of this operation will be assigned to payload, so it is important to return the modified payload. This can be very useful, for example if you want a single point of decoding Avro messages and want the payload as a hash instead of a binary.
 
 ```ruby
 class MyHandler
@@ -195,7 +213,7 @@ The hander life cycle can be illustrated as:
 
 or optionally,
 
-  `.start` -> `#before_consume` -> `.around_consume` [ `#consume` ] -> `.stop`
+  `.start` -> `#before_consume` -> `#around_consume` [ `#consume` ] -> `.stop`
 
 ### <a name="usage-producing-messages-to-kafka"></a> Producing messages to Kafka
 
@@ -506,7 +524,7 @@ describe MyConsumer do
   let(:metadata) { Hash(foo: 'bar') }
 
   it 'consumes my message' do
-    expect(described_class).to receive(:around_consume).with(payload, metadata).once.and_call_original
+    expect_any_instance_of(described_class).to receive(:around_consume).with(payload, metadata).once.and_call_original
     expect_any_instance_of(described_class).to receive(:before_consume).with(payload).once.and_call_original
     expect_any_instance_of(described_class).to receive(:consume).with(payload, metadata).once.and_call_original
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ class MyHandler
 end
 ```
 
-Note: `around_consume` can also be defined as a class method. If defined, the class method `.around_consume` takes precedence.
+Note: `around_consume` was previously defined as a class method. The current code supports both implementations, giving precendence to the class method, but future versions will no longer support `.around_consume`.
 
 ```ruby
 class MyHandler

--- a/lib/phobos.rb
+++ b/lib/phobos.rb
@@ -100,6 +100,10 @@ module Phobos
       appenders
     end
 
+    def deprecate(message)
+      warn "DEPRECATION WARNING: #{message} #{Kernel.caller.first}"
+    end
+
     private
 
     def fetch_settings(configuration)

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -57,7 +57,13 @@ module Phobos
       def process_message(payload)
         instrument('listener.process_message', @metadata) do
           handler = @listener.handler_class.new
-          preprocessed_payload = handler.before_consume(payload, @metadata)
+          preprocessed_payload = begin
+            handler.before_consume(payload, @metadata)
+          rescue ArgumentError => e
+            Phobos.deprecate("before_consume now expects metadata as second argument, please update your consumer."\
+              " This will not be backwards compatible in the future.")
+            handler.before_consume(payload)
+          end
           consume_block = Proc.new { handler.consume(preprocessed_payload, @metadata) }
 
           if @listener.handler_class.respond_to?(:around_consume)

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -62,8 +62,8 @@ module Phobos
 
           if @listener.handler_class.respond_to?(:around_consume)
             # around_consume class method implementation
-            warn "#{Kernel.caller.first} around_consume has been moved to instance method, please update your consumer."\
-              " This will not be backwards compatible in the future."
+            Phobos.deprecate("around_consume has been moved to instance method, please update your consumer."\
+              " This will not be backwards compatible in the future.")
             @listener.handler_class.around_consume(preprocessed_payload, @metadata, &consume_block)
           else
             # around_consume instance method implementation

--- a/lib/phobos/actions/process_message.rb
+++ b/lib/phobos/actions/process_message.rb
@@ -57,12 +57,16 @@ module Phobos
       def process_message(payload)
         instrument('listener.process_message', @metadata) do
           handler = @listener.handler_class.new
-          preprocessed_payload = handler.before_consume(payload)
+          preprocessed_payload = handler.before_consume(payload, @metadata)
           consume_block = Proc.new { handler.consume(preprocessed_payload, @metadata) }
 
           if @listener.handler_class.respond_to?(:around_consume)
+            # around_consume class method implementation
+            warn "#{Kernel.caller.first} around_consume has been moved to instance method, please update your consumer."\
+              " This will not be backwards compatible in the future."
             @listener.handler_class.around_consume(preprocessed_payload, @metadata, &consume_block)
           else
+            # around_consume instance method implementation
             handler.around_consume(preprocessed_payload, @metadata, &consume_block)
           end
         end

--- a/lib/phobos/handler.rb
+++ b/lib/phobos/handler.rb
@@ -4,7 +4,7 @@ module Phobos
       base.extend(ClassMethods)
     end
 
-    def before_consume(payload)
+    def before_consume(payload, metadata)
       payload
     end
 

--- a/lib/phobos/handler.rb
+++ b/lib/phobos/handler.rb
@@ -12,15 +12,15 @@ module Phobos
       raise NotImplementedError
     end
 
+    def around_consume(payload, metadata)
+      yield
+    end
+
     module ClassMethods
       def start(kafka_client)
       end
 
       def stop
-      end
-
-      def around_consume(payload, metadata)
-        yield
       end
     end
   end

--- a/spec/lib/phobos/actions/process_message_spec.rb
+++ b/spec/lib/phobos/actions/process_message_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Phobos::Actions::ProcessMessage do
 
   it 'processes the message by calling around consume, before consume and consume of the handler' do
     expect_any_instance_of(TestHandler).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
-    expect_any_instance_of(TestHandler).to receive(:before_consume).with(payload).once.and_call_original
+    expect_any_instance_of(TestHandler).to receive(:before_consume).with(payload, subject.metadata).once.and_call_original
     expect_any_instance_of(TestHandler).to receive(:consume).with(payload, subject.metadata).once.and_call_original
 
     subject.execute
@@ -59,7 +59,7 @@ RSpec.describe Phobos::Actions::ProcessMessage do
 
     it 'supports and prefers around_consume if defined as a class method' do
       expect(TestHandler2).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
-      expect_any_instance_of(TestHandler2).to receive(:before_consume).with(payload).once.and_call_original
+      expect_any_instance_of(TestHandler2).to receive(:before_consume).with(payload, subject.metadata).once.and_call_original
       expect_any_instance_of(TestHandler2).to receive(:consume).with(payload, subject.metadata).once.and_call_original
 
       subject.execute

--- a/spec/lib/phobos/actions/process_message_spec.rb
+++ b/spec/lib/phobos/actions/process_message_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe Phobos::Actions::ProcessMessage do
     include Phobos::Handler
   end
 
+  # For backwards compatibility
+  class TestHandler2 < Phobos::EchoHandler
+    include Phobos::Handler
+
+    def self.around_consume(payload, metadata)
+      yield
+    end
+  end
+
   let(:payload) { 'message-1234' }
   let(:topic) { 'test-topic' }
   let(:message) do
@@ -32,11 +41,29 @@ RSpec.describe Phobos::Actions::ProcessMessage do
   end
 
   it 'processes the message by calling around consume, before consume and consume of the handler' do
-    expect(TestHandler).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
+    expect_any_instance_of(TestHandler).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
     expect_any_instance_of(TestHandler).to receive(:before_consume).with(payload).once.and_call_original
     expect_any_instance_of(TestHandler).to receive(:consume).with(payload, subject.metadata).once.and_call_original
 
     subject.execute
+  end
+
+  context '.around_consumed defined' do
+    let(:listener) do
+      Phobos::Listener.new(
+        handler: TestHandler2,
+        group_id: 'test-group',
+        topic: topic
+      )
+    end
+
+    it 'supports and prefers around_consume if defined as a class method' do
+      expect(TestHandler2).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
+      expect_any_instance_of(TestHandler2).to receive(:before_consume).with(payload).once.and_call_original
+      expect_any_instance_of(TestHandler2).to receive(:consume).with(payload, subject.metadata).once.and_call_original
+
+      subject.execute
+    end
   end
 
   context 'with encoding' do

--- a/spec/lib/phobos/actions/process_message_spec.rb
+++ b/spec/lib/phobos/actions/process_message_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe Phobos::Actions::ProcessMessage do
 
     it 'supports and prefers around_consume if defined as a class method' do
       expect(TestHandler2).to receive(:around_consume).with(payload, subject.metadata).once.and_call_original
+      expect(Phobos).to receive(:deprecate).once
       expect_any_instance_of(TestHandler2).to receive(:before_consume).with(payload, subject.metadata).once.and_call_original
       expect_any_instance_of(TestHandler2).to receive(:consume).with(payload, subject.metadata).once.and_call_original
 

--- a/spec/lib/phobos/handler_spec.rb
+++ b/spec/lib/phobos/handler_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Phobos::Handler do
     expect { TestIncludeHandler.stop }.to_not raise_error
   end
 
-  it 'includes default ".around_consume"' do
-    expect { |block| TestIncludeHandler.around_consume('payload', {}, &block) }
+  it 'includes default "#around_consume"' do
+    expect { |block| TestIncludeHandler.new.around_consume('payload', {}, &block) }
       .to yield_with_no_args
   end
 

--- a/spec/lib/phobos/test/helper_spec.rb
+++ b/spec/lib/phobos/test/helper_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Phobos::Test::Helper do
     include Phobos::Handler
     CONSUME_VISITED = 'consume was visited'
 
-    def before_consume(payload)
+    def before_consume(payload, metadata)
       payload
     end
 
@@ -21,6 +21,7 @@ RSpec.describe Phobos::Test::Helper do
 
   let(:payload) { 'foo' }
   let(:metadata) { Hash(foo: 'bar') }
+  let(:listener_metadata) { Hash(key: nil, partition: 0, offset: 13, retry_count: 0) }
   let(:topic) { Phobos::Test::Helper::Topic }
   let(:group_id) { Phobos::Test::Helper::Group }
 
@@ -34,7 +35,7 @@ RSpec.describe Phobos::Test::Helper do
     end
 
     it 'invokes handler before_consume with payload' do
-      expect_any_instance_of(TestHandler).to receive(:before_consume).with(payload)
+      expect_any_instance_of(TestHandler).to receive(:before_consume).with(payload, listener_metadata)
       process_message(handler: TestHandler, payload: payload)
     end
 


### PR DESCRIPTION
## Reasoning:
1) **Consistency/readability**: It's generally confusing that `#before_consume` is an instance method on the handler and `.around_consume` is a class method. 

2) **Flexibility**: Allows users to set custom instance variables on the handler that will be accessible in around_consume.

This feature has come up consistently during development. For example, we have built some custom logic into around_consume that relies on metadata from the original payload. We lose that metadata in the before_consume step, forcing us to put all of the logic into around_consume. Another example is error handling for before_consume. In some cases we want to catch exceptions in before_consume and continue to proceed with message processing. Setting an instance variable on the handler is a logical way to signal this downstream.