### PR TITLE
Enable partition keys to be separate from payload keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## UNRELEASED
+- Added ability to send partition keys separate from messsage keys.
 
 ## [1.8.0] - 2018-07-22
 ### Added

--- a/lib/phobos/producer.rb
+++ b/lib/phobos/producer.rb
@@ -13,12 +13,12 @@ module Phobos
         @host_obj = host_obj
       end
 
-      def publish(topic, payload, key = nil)
-        class_producer.publish(topic, payload, key)
+      def publish(topic, payload, key=nil, partition_key=nil)
+        class_producer.publish(topic, payload, key, partition_key)
       end
 
-      def async_publish(topic, payload, key = nil)
-        class_producer.async_publish(topic, payload, key)
+      def async_publish(topic, payload, key=nil, partition_key=nil)
+        class_producer.async_publish(topic, payload, key, partition_key)
       end
 
       # @param messages [Array(Hash(:topic, :payload, :key))]
@@ -65,8 +65,9 @@ module Phobos
           producer_store[:kafka_client]
         end
 
-        def publish(topic, payload, key = nil)
-          publish_list([{ topic: topic, payload: payload, key: key }])
+        def publish(topic, payload, key=nil, partition_key=nil)
+          publish_list([{ topic: topic, payload: payload, key: key,
+                          partition_key: partition_key }])
         end
 
         def publish_list(messages)
@@ -88,8 +89,9 @@ module Phobos
           producer_store[:async_producer]
         end
 
-        def async_publish(topic, payload, key = nil)
-          async_publish_list([{ topic: topic, payload: payload, key: key }])
+        def async_publish(topic, payload, key=nil, partition_key=nil)
+          async_publish_list([{ topic: topic, payload: payload, key: key,
+                                partition_key: partition_key }])
         end
 
         def async_publish_list(messages)
@@ -116,10 +118,10 @@ module Phobos
 
         def produce_messages(producer, messages)
           messages.each do |message|
+            partition_key = message[:partition_key] || message[:key]
             producer.produce(message[:payload], topic: message[:topic],
                                                 key: message[:key],
-                                                partition_key: message[:key]
-            )
+                                                partition_key: partition_key)
           end
         end
 

--- a/spec/lib/phobos/producer_spec.rb
+++ b/spec/lib/phobos/producer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Phobos::Producer do
 
       expect(TestProducer1.producer)
         .to receive(:publish_list)
-        .with([{ topic: 'topic', payload: 'message', key: 'key' }])
+        .with([{ topic: 'topic', payload: 'message', key: 'key', partition_key: nil }])
 
       subject.producer.publish('topic', 'message', 'key')
     end
@@ -29,10 +29,10 @@ RSpec.describe Phobos::Producer do
 
       expect(TestProducer1.producer)
         .to receive(:async_publish_list)
-        .with([{ topic: 'topic', payload: 'message', key: 'key' }])
+        .with([{ topic: 'topic', payload: 'message', key: 'key', partition_key: 'partition_key' }])
 
       TestProducer1.producer.create_async_producer
-      subject.producer.async_publish('topic', 'message', 'key')
+      subject.producer.async_publish('topic', 'message', 'key', 'partition_key')
     end
   end
 
@@ -54,7 +54,7 @@ RSpec.describe Phobos::Producer do
 
         expect(producer)
           .to receive(:produce)
-          .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'key-1')
+          .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1')
 
         expect(producer)
           .to receive(:produce)
@@ -65,7 +65,7 @@ RSpec.describe Phobos::Producer do
         expect(kafka_client).to_not receive(:close)
 
         subject.producer.publish_list([
-          { payload: 'message-1', topic: 'topic-1', key: 'key-1' },
+          { payload: 'message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1' },
           { payload: 'message-2', topic: 'topic-2', key: 'key-2' }
         ])
       end
@@ -85,7 +85,7 @@ RSpec.describe Phobos::Producer do
 
         expect(producer)
           .to receive(:produce)
-          .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'key-1')
+          .with('message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1')
 
         expect(producer)
           .to receive(:produce)
@@ -96,7 +96,7 @@ RSpec.describe Phobos::Producer do
         expect(kafka_client).to_not receive(:close)
 
         subject.producer.publish_list([
-          { payload: 'message-1', topic: 'topic-1', key: 'key-1' },
+          { payload: 'message-1', topic: 'topic-1', key: 'key-1', partition_key: 'part-key-1' },
           { payload: 'message-2', topic: 'topic-2', key: 'key-2' }
         ])
       end


### PR DESCRIPTION
Currently, Phobos only uses message/payload keys. It automatically sets the partition key to be the same as the payload key.

There are use cases where these should be separate. For example, say there is a comment on a post. The Comments topic would want the comment ID to be the payload key (since it indicates that all updates to that individual comment should be compacted) while the partition key would likely be the post (so all actions related to the same post are put in the same partition).

This PR adds this functionality into Phobos.