### PR TITLE
#98: Fix crash on startup with namespaced handlers

### DIFF
--- a/lib/phobos/cli/start.rb
+++ b/lib/phobos/cli/start.rb
@@ -39,7 +39,11 @@ module Phobos
         Phobos.config.listeners.each do |listener|
           handler = listener.handler
 
-          Object.const_defined?(handler) || error_exit("Handler '#{handler}' not defined")
+          begin
+            handler.constantize
+          rescue NameError
+            error_exit("Handler '#{handler}' not defined")
+          end
 
           delivery = listener.delivery
           if delivery.nil?

--- a/lib/phobos/cli/start.rb
+++ b/lib/phobos/cli/start.rb
@@ -35,7 +35,7 @@ module Phobos
         File.exist?(config_file) || error_exit("Config file not found (#{config_file})")
       end
 
-      def validate_listeners!
+      def validate_listeners! # rubocop:disable Metrics/MethodLength
         Phobos.config.listeners.each do |listener|
           handler = listener.handler
 


### PR DESCRIPTION
Issue was introduced by switching `constantize` in for `Object.const_defined?`. This only looks at the top level and doesn't try to load namespaces.